### PR TITLE
Add a contact information to the result structure of fetching each keyboard definition.

### DIFF
--- a/functions/src/admin/fetch-keyboard-definition-by-id-command.ts
+++ b/functions/src/admin/fetch-keyboard-definition-by-id-command.ts
@@ -67,6 +67,7 @@ export class FetchKeyboardDefinitionByIdCommand extends AbstractCommand<IFetchKe
           .other_place_source_code_evidence,
         otherPlacePublisherEvidence: documentSnapshot.data()!
           .other_place_publisher_evidence,
+        contactInformation: documentSnapshot.data()!.contact_information,
         githubUid: providerData.uid,
         githubDisplayName: providerData.displayName,
         githubEmail: providerData.email,

--- a/functions/src/admin/fetch-keyboard-definition-list-by-status-command.ts
+++ b/functions/src/admin/fetch-keyboard-definition-list-by-status-command.ts
@@ -57,6 +57,7 @@ export class FetchKeyboardDefinitionListByStatusCommand extends AbstractCommand<
             .other_place_source_code_evidence,
           otherPlacePublisherEvidence: doc.data()
             .other_place_publisher_evidence,
+          contactInformation: doc.data().contact_information,
         };
       }),
     };

--- a/functions/src/utils/types.ts
+++ b/functions/src/utils/types.ts
@@ -42,6 +42,7 @@ export interface IKeyboardDefinition {
   readonly otherPlaceHowToGet: string;
   readonly otherPlaceSourceCodeEvidence: string;
   readonly otherPlacePublisherEvidence: string;
+  readonly contactInformation: string;
   readonly createdAt: number;
   readonly updatedAt: number;
 }


### PR DESCRIPTION
To show the admin page, add a contact information to the result data at fetching each keyboard definiiton.

https://github.com/remap-keys/remap/issues/573