### PR TITLE
Fix NeedOrganizationMember decorator organizationId retrieval

### DIFF
--- a/functions/src/utils/decorators.ts
+++ b/functions/src/utils/decorators.ts
@@ -70,9 +70,8 @@ export function NeedOrganizationMember() {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this;
       return new Promise((resolve, _reject) => {
-        const data = args[0];
-        const organizationId = data.organizationId;
         const request = args[0] as CallableRequest;
+        const organizationId = request.data.organizationId;
         const uid = request.auth!.uid;
         (self as AbstractCommand).checkUserIsOrganizationMember
           .apply(self, [uid, organizationId])


### PR DESCRIPTION
## Summary
- Fix bug in `@NeedOrganizationMember()` decorator where `organizationId` was incorrectly retrieved
- Changed from `args[0].organizationId` to `args[0].data.organizationId` 
- Resolves "documentPath is not a valid resource path" error

## Test plan
- [x] Build passes without errors
- [x] Decorator now correctly retrieves organizationId from request.data
- [x] Error that was preventing fetch-organization-members-command from working is resolved

🤖 Generated with [Claude Code](https://claude.ai/code)