### PR TITLE
Migrate build server URL from GCE to Cloud Run

### DIFF
--- a/functions/src/keyboards/create-firmware-building-task-command.ts
+++ b/functions/src/keyboards/create-firmware-building-task-command.ts
@@ -8,7 +8,8 @@ import { CallableRequest, CallableResponse } from 'firebase-functions/https';
 const PROJECT_ID = 'remap-b2d08';
 const LOCATION = 'asia-northeast1';
 const QUEUE = 'build-task-queue';
-const BUILD_SERVER_URL = 'https://build.remap-keys.app';
+const BUILD_SERVER_URL =
+  'https://remap-build-server-481322013727.asia-northeast1.run.app';
 const BUILD_SERVER_AUTH_SA_EMAIL = `remap-build-server-task-auth@${PROJECT_ID}.iam.gserviceaccount.com`;
 
 export class CreateFirmwareBuildingTaskCommand extends AbstractCommand<IResult> {

--- a/functions/src/keyboards/create-workbench-building-task-command.ts
+++ b/functions/src/keyboards/create-workbench-building-task-command.ts
@@ -8,7 +8,8 @@ import { google } from '@google-cloud/tasks/build/protos';
 const PROJECT_ID = 'remap-b2d08';
 const LOCATION = 'asia-northeast1';
 const QUEUE = 'build-task-queue';
-const BUILD_SERVER_URL = 'https://build.remap-keys.app';
+const BUILD_SERVER_URL =
+  'https://remap-build-server-481322013727.asia-northeast1.run.app';
 const BUILD_SERVER_AUTH_SA_EMAIL = `remap-build-server-task-auth@${PROJECT_ID}.iam.gserviceaccount.com`;
 
 export class CreateWorkbenchBuildingTaskCommand extends AbstractCommand<IResult> {


### PR DESCRIPTION
## Summary
- Update `BUILD_SERVER_URL` in both `CreateFirmwareBuildingTaskCommand` and `CreateWorkbenchBuildingTaskCommand` from the old GCE endpoint (`https://build.remap-keys.app`) to the new Cloud Run endpoint (`https://remap-build-server-481322013727.asia-northeast1.run.app`).
- Follows the migration of `remap-build-server` from GCE MIG to Cloud Run (see remap-keys/remap-build-server#39).
- OIDC authentication with service account `remap-build-server-task-auth@remap-b2d08.iam.gserviceaccount.com` remains unchanged; the new Cloud Run service validates the JWT on the Go side.

## Test plan
- [x] `yarn build` (lint + tsc) passes
- [x] `yarn test` passes
- [ ] After merge & deploy: trigger a firmware build task via Remap UI and confirm it is dispatched to the new Cloud Run endpoint
- [ ] After merge & deploy: trigger a workbench build task and confirm it is dispatched to the new Cloud Run endpoint
- [ ] Once traffic is flowing to Cloud Run, stop the old GCE MIG (handled on remap-build-server side)